### PR TITLE
xdg: Install livecd variant for kscreenlocker

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ project(
 )
 
 path_prefix = get_option('prefix')
+path_sysconfdir = get_option('sysconfdir')
 path_datadir = join_paths(path_prefix, get_option('datadir'))
 path_schemadir = join_paths(path_datadir, 'glib-2.0', 'schemas')
 
@@ -35,6 +36,7 @@ report = [
     '    prefix:                                 @0@'.format(path_prefix),
     '    datadir:                                @0@'.format(path_datadir),
     '    envdir:                                 @0@'.format(path_envdir),
+    '    etcdir:                                 @0@'.format(path_sysconfdir),
 ]
 
 # Output some stuff to validate the build config

--- a/xdg/livecd/kscreenlockerrc
+++ b/xdg/livecd/kscreenlockerrc
@@ -1,0 +1,6 @@
+[Greeter]
+Theme=solusdark.desktop
+
+[Daemon]
+Autolock=false
+LockOnResume=false

--- a/xdg/livecd/meson.build
+++ b/xdg/livecd/meson.build
@@ -1,0 +1,10 @@
+livexdg_data = [
+    'kscreenlockerrc',
+]
+
+livexdg_dir = join_paths(path_sysconfdir, 'xdg')
+
+install_data(
+    livexdg_data,
+    install_dir: livexdg_dir,
+)

--- a/xdg/meson.build
+++ b/xdg/meson.build
@@ -26,3 +26,5 @@ install_data(
     xdg_data,
     install_dir: xdg_dir,
 )
+
+subdir('livecd')


### PR DESCRIPTION
Which disables autolocking.

It uses /etc/ which is not stateless but it is only for the livecd so eh.