### PR TITLE
fix theme json format

### DIFF
--- a/solus-desktoptheme/Solus/desktoptheme/solus-dark/metadata.json
+++ b/solus-desktoptheme/Solus/desktoptheme/solus-dark/metadata.json
@@ -1,19 +1,18 @@
 {
-    "KPackageStructure": "Plasma/LookAndFeel",
+    "KPackageStructure": "Plasma/Theme",
     "KPlugin": {
         "Authors": [
             {
-                "Name": "Solus Plasma"
-
+                "Name": "Solus Project Developers"
             }
         ],
         "Category": "",
-        "Description": "Solus Plasma",
-        "Id": "solusdark.desktop",
+        "Description": "Solus Plasma dark theme",
+        "Id": "solus-dark",
         "License": "Apache-2.0",
-        "Name": "SolusDark",
+        "Name": "Solus Dark",
         "ServiceTypes": [
-            "Plasma/LookAndFeel"
+            "Plasma/Theme"
         ],
         "Version": "0.1",
         "Website": "https://www.getsol.us"

--- a/solus-desktoptheme/Solus/desktoptheme/solus-light/metadata.json
+++ b/solus-desktoptheme/Solus/desktoptheme/solus-light/metadata.json
@@ -1,19 +1,18 @@
 {
-    "KPackageStructure": "Plasma/LookAndFeel",
+    "KPackageStructure": "Plasma/Theme",
     "KPlugin": {
         "Authors": [
             {
-                "Name": "Solus Plasma"
-
+                "Name": "Solus Project Developers"
             }
         ],
         "Category": "",
-        "Description": "Solus Plasma",
-        "Id": "solusdark.desktop",
+        "Description": "Solus Plasma light theme",
+        "Id": "solus-light",
         "License": "Apache-2.0",
-        "Name": "SolusDark",
+        "Name": "Solus Light",
         "ServiceTypes": [
-            "Plasma/LookAndFeel"
+            "Plasma/Theme"
         ],
         "Version": "0.1",
         "Website": "https://www.getsol.us"

--- a/solus-desktoptheme/Solus/look-and-feel/solusdark.desktop/contents/defaults
+++ b/solus-desktoptheme/Solus/look-and-feel/solusdark.desktop/contents/defaults
@@ -2,13 +2,13 @@
 widgetStyle=Breeze
 
 [kdeglobals][General]
-ColorScheme=SolusDark
+ColorScheme=BreezeDark
 
 [kdeglobals][Icons]
 Theme=breeze-dark
 
 [plasmarc][Theme]
-name=solus-dark
+name=default
 
 [Wallpaper]
 Image=SolusPlasma

--- a/solus-desktoptheme/Solus/look-and-feel/soluslight.desktop/contents/defaults
+++ b/solus-desktoptheme/Solus/look-and-feel/soluslight.desktop/contents/defaults
@@ -2,13 +2,13 @@
 widgetStyle=Breeze
 
 [kdeglobals][General]
-ColorScheme=SolusLight
+ColorScheme=BreezeLight
 
 [kdeglobals][Icons]
 Theme=breeze
 
 [plasmarc][Theme]
-name=solus-light
+name=default
 
 [Wallpaper]
 Image=SolusPlasma

--- a/solus-desktoptheme/Solus/look-and-feel/soluslight.desktop/metadata.json
+++ b/solus-desktoptheme/Solus/look-and-feel/soluslight.desktop/metadata.json
@@ -1,4 +1,5 @@
 {
+    "KPackageStructure": "Plasma/LookAndFeel",
     "KPlugin": {
         "Authors": [
             {


### PR DESCRIPTION
Going to system settings -> colors & themes -> plasma style -> clicking any other section and going back to plasma style resulted in a crash.

```
KPackageStructure of KPluginMetaData(pluginId:"solusdark.desktop", fileName: "/usr/share/plasma/look-and-feel/solusdark.desktop/metadata.json") does not match requested format "Plasma/LookAndFeel"
KPackageStructure of KPluginMetaData(pluginId:"soluslight.desktop", fileName: "/usr/share/plasma/look-and-feel/soluslight.desktop/metadata.json") does not match requested format "Plasma/LookAndFeel
```

From looking at some other themes this is how it should be structured and no longer crashes.

All themes have been tested and appear to be working.